### PR TITLE
Android FileProvider

### DIFF
--- a/src/android/MediaFunctions.java
+++ b/src/android/MediaFunctions.java
@@ -58,7 +58,31 @@ public class MediaFunctions {
                     ActivityCompat.requestPermissions(ParentActivity,
                             new String[]{android.Manifest.permission.WRITE_EXTERNAL_STORAGE},
                             MY_PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE_GALLERY);
-                }
+                } 
+            }
+        });
+        builder.setNegativeButton(ParentActivity.getString(com.ahmedadeltito.photoeditor.R.string.not_now), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                Toast.makeText(ParentActivity, ParentActivity.getString(com.ahmedadeltito.photoeditor.R.string.media_access_denied_msg), Toast.LENGTH_SHORT).show();
+            }
+        });
+        builder.show();
+    }
+	
+	   private void showMenu64(String base64){
+        AlertDialog.Builder builder = new AlertDialog.Builder(ParentActivity);
+        builder.setMessage(ParentActivity.getString(com.ahmedadeltito.photoeditor.R.string.access_media_permissions_msg));
+        builder.setPositiveButton(ParentActivity.getString(com.ahmedadeltito.photoeditor.R.string.continue_txt), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                    ActivityCompat.requestPermissions(ParentActivity,
+                            new String[]{android.Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                            MY_PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE_GALLERY);
+					String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+					String imageName = "IMG_" + timeStamp + ".jpg";
+					String selectedOutputPath = com.outsystems.imageeditorplugin.Utils.FileUtils.saveImage("PhotoEditorSDK", imageName, base64);
+					onPhotoTaken(selectedOutputPath);
             }
         });
         builder.setNegativeButton(ParentActivity.getString(com.ahmedadeltito.photoeditor.R.string.not_now), new DialogInterface.OnClickListener() {
@@ -110,11 +134,16 @@ public class MediaFunctions {
     }
 
     public void editBase64Image(String base64){
-        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+		int permissionCheck = PermissionChecker.checkCallingOrSelfPermission(ParentActivity,
+                android.Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        if (permissionCheck != PackageManager.PERMISSION_GRANTED) {
+			showMenu64(base64);
+			} else {
+		        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageName = "IMG_" + timeStamp + ".jpg";
         String selectedOutputPath = com.outsystems.imageeditorplugin.Utils.FileUtils.saveImage("PhotoEditorSDK", imageName, base64);
-
         onPhotoTaken(selectedOutputPath);
+		}
     }
 
     private Uri getOutputMediaFile() {

--- a/src/android/MediaFunctions.java
+++ b/src/android/MediaFunctions.java
@@ -28,6 +28,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import com.outsystems.imageeditorplugin.Intents.IntentsDefinition;
 
+import android.support.v4.content.FileProvider;
+
 public class MediaFunctions {
 
     protected static final int MY_PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE_GALLERY = 0x3;
@@ -135,7 +137,7 @@ public class MediaFunctions {
             Log.d("MediaAbstractActivity", "selected camera path "
                     + selectedOutputPath);
             mediaFile = new File(selectedOutputPath);
-            return Uri.fromFile(mediaFile);
+	    return FileProvider.getUriForFile(ParentActivity, ParentActivity.getApplicationContext().getPackageName() + ".provider", mediaFile);
         } else {
             return null;
         }

--- a/src/android/libs/photoeditor/src/main/AndroidManifest.xml
+++ b/src/android/libs/photoeditor/src/main/AndroidManifest.xml
@@ -18,6 +18,15 @@
             android:label="@string/title_activity_photo_editor"
             android:theme="@style/AppTheme.NoActionBar"
             android:windowSoftInputMode="stateHidden|adjustPan" />
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+                <meta-data
+                    android:name="android.support.FILE_PROVIDER_PATHS"
+                    android:resource="@xml/provider_paths"/>
+        </provider>
     </application>
 
 </manifest>

--- a/src/android/libs/photoeditor/src/main/res/xml/provider_paths.xml
+++ b/src/android/libs/photoeditor/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+</paths>

--- a/src/android/libs/photoeditorsdk/src/main/AndroidManifest.xml
+++ b/src/android/libs/photoeditorsdk/src/main/AndroidManifest.xml
@@ -4,6 +4,15 @@
 
     <application android:allowBackup="true" android:label="@string/app_name"
         android:supportsRtl="true">
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+                <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
 
     </application>
 

--- a/src/android/libs/photoeditorsdk/src/main/res/xml/provider_paths.xml
+++ b/src/android/libs/photoeditorsdk/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+</paths>


### PR DESCRIPTION
FileUriExposedException killed the image from displaying, resulting in a black screen.

Changed Uri.fromFile() to FileProvider as outlined in https://inthecheesefactory.com/blog/how-to-share-access-to-file-with-fileprovider-on-android-nougat/en